### PR TITLE
Fix note header classname

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -84,7 +84,7 @@ button .delete {
     #00000000 100%
   );
 }
-.note-heder {
+.note-header {
   display: flex;
   top: 15px;
   right: 10px;

--- a/src/pages/notes/components/Note.tsx
+++ b/src/pages/notes/components/Note.tsx
@@ -35,7 +35,7 @@ const Note: FC<{ note: NoteType }> = ({ note }) => {
       layout="position"
       style={{ backgroundColor: bgColor, color: textColor, "--noteTextColor": textColor } as React.CSSProperties}
     >
-      <div className="note-heder">
+      <div className="note-header">
         <small style={{ fontSize: "0.6em" }}></small>
         <PinNoteButton color={textColor}
           onClick={() => updateNote({ ...note, isPined: !note.isPined })}


### PR DESCRIPTION
## Summary
- rename `.note-heder` class to `.note-header`
- update Note component to use the corrected class

## Testing
- `npx eslint -c .eslintrc.cjs .` *(fails: A config object is using the "root" key, which is not supported in flat config system)*
- `npm run build` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684931f80d848327862afe7884f3ff9c