### PR TITLE
Fix NotFound redirect effect

### DIFF
--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -5,6 +5,6 @@ export const NotFound = () => {
   const navigate = useNavigate();
   useEffect(() => {
     navigate("/tasks");
-  });
+  }, []);
   return <div></div>;
 };


### PR DESCRIPTION
## Summary
- adjust `src/components/NotFound.tsx` to run redirect on mount only

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849329e31b8832789cbde77e11080f8