### PR TITLE
Fix service worker registration

### DIFF
--- a/src/serviceWorkerRegistration.ts
+++ b/src/serviceWorkerRegistration.ts
@@ -2,11 +2,11 @@ export function register() {
     if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
             navigator.serviceWorker
-                .register('../public/manifest.webmanifest')
-                .then(reg => {
+                .register('/sw.js')
+                .then((reg) => {
                     console.log('SW registered: ', reg);
                 })
-                .catch(err => {
+                .catch((err) => {
                     console.log('SW registration failed: ', err);
                 });
         });


### PR DESCRIPTION
## Summary
- correct service worker registration path

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683fe89367ec8327aa90b9eb9bcdc8cc