### PR TITLE
Fix service worker routing for Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,6 +26,18 @@
     Content-Type = "image/png"
 
 [[redirects]]
+  from = "/sw.js"
+  to = "/sw.js"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/workbox-*"
+  to = "/workbox-:splat"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 404


### PR DESCRIPTION
## Summary
- serve PWA service worker files on Netlify

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683fe89377088327a19abf6f98ee2f17