### PR TITLE
Fix manifest icon content type

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-  <link rel="manifest" href="./public/manifest.json" />
+  <link rel="manifest" href="/manifest.webmanifest" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#000000" />
   <title>Donoud</title>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,12 +3,12 @@
     "name": "Donoud",
     "icons": [
       {
-        "src": "./icon256.svg",
+        "src": "/icon256.svg",
         "sizes": "192x192",
         "type": "image/svg+xml"
       },
       {
-        "src": "./icon512.svg",
+        "src": "/icon512.svg",
         "sizes": "512x512",
         "type": "image/svg+xml"
       }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,12 +5,12 @@
       {
         "src": "./icon256.svg",
         "sizes": "192x192",
-        "type": "image/png"
+        "type": "image/svg+xml"
       },
       {
         "src": "./icon512.svg",
         "sizes": "512x512",
-        "type": "image/png"
+        "type": "image/svg+xml"
       }
     ],
     "start_url": ".",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,12 +3,12 @@
     "name": "Donoud",
     "icons": [
       {
-        "src": "/icon256.svg",
+        "src": "icon256.svg",
         "sizes": "192x192",
         "type": "image/svg+xml"
       },
       {
-        "src": "/icon512.svg",
+        "src": "icon512.svg",
         "sizes": "512x512",
         "type": "image/svg+xml"
       }

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,43 +1,43 @@
 {
   "icons": [
     {
-      "src": "./icon256.svg",
+      "src": "/icon256.svg",
       "type": "image/svg+xml",
       "sizes": "48x48",
       "purpose": "any maskable"
     },
     {
-      "src": "./icon256.svg",
+      "src": "/icon256.svg",
       "type": "image/svg+xml",
       "sizes": "72x72",
       "purpose": "any maskable"
     },
     {
-      "src": "./icon256.svg",
+      "src": "/icon256.svg",
       "type": "image/svg+xml",
       "sizes": "96x96",
       "purpose": "any maskable"
     },
     {
-      "src": "./icon256.svg",
+      "src": "/icon256.svg",
       "type": "image/svg+xml",
       "sizes": "128x128",
       "purpose": "any maskable"
     },
     {
-      "src": "./icon256.svg",
+      "src": "/icon256.svg",
       "type": "image/svg+xml",
       "sizes": "192x192",
       "purpose": "any maskable"
     },
     {
-      "src": "./icon256.svg",
+      "src": "/icon256.svg",
       "type": "image/svg+xml",
       "sizes": "256x256",
       "purpose": "any maskable"
     },
     {
-      "src": "./icon256.svg",
+      "src": "/icon256.svg",
       "type": "image/svg+xml",
       "sizes": "512x512",
       "purpose": "any maskable"

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,43 +1,43 @@
 {
   "icons": [
     {
-      "src": "/icon256.svg",
+      "src": "icon256.svg",
       "type": "image/svg+xml",
       "sizes": "48x48",
       "purpose": "any maskable"
     },
     {
-      "src": "/icon256.svg",
+      "src": "icon256.svg",
       "type": "image/svg+xml",
       "sizes": "72x72",
       "purpose": "any maskable"
     },
     {
-      "src": "/icon256.svg",
+      "src": "icon256.svg",
       "type": "image/svg+xml",
       "sizes": "96x96",
       "purpose": "any maskable"
     },
     {
-      "src": "/icon256.svg",
+      "src": "icon256.svg",
       "type": "image/svg+xml",
       "sizes": "128x128",
       "purpose": "any maskable"
     },
     {
-      "src": "/icon256.svg",
+      "src": "icon256.svg",
       "type": "image/svg+xml",
       "sizes": "192x192",
       "purpose": "any maskable"
     },
     {
-      "src": "/icon256.svg",
+      "src": "icon256.svg",
       "type": "image/svg+xml",
       "sizes": "256x256",
       "purpose": "any maskable"
     },
     {
-      "src": "/icon256.svg",
+      "src": "icon512.svg",
       "type": "image/svg+xml",
       "sizes": "512x512",
       "purpose": "any maskable"

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -2,43 +2,43 @@
   "icons": [
     {
       "src": "./icon256.svg",
-      "type": "image/png",
+      "type": "image/svg+xml",
       "sizes": "48x48",
       "purpose": "any maskable"
     },
     {
       "src": "./icon256.svg",
-      "type": "image/png",
+      "type": "image/svg+xml",
       "sizes": "72x72",
       "purpose": "any maskable"
     },
     {
       "src": "./icon256.svg",
-      "type": "image/png",
+      "type": "image/svg+xml",
       "sizes": "96x96",
       "purpose": "any maskable"
     },
     {
       "src": "./icon256.svg",
-      "type": "image/png",
+      "type": "image/svg+xml",
       "sizes": "128x128",
       "purpose": "any maskable"
     },
     {
       "src": "./icon256.svg",
-      "type": "image/png",
+      "type": "image/svg+xml",
       "sizes": "192x192",
       "purpose": "any maskable"
     },
     {
       "src": "./icon256.svg",
-      "type": "image/png",
+      "type": "image/svg+xml",
       "sizes": "256x256",
       "purpose": "any maskable"
     },
     {
       "src": "./icon256.svg",
-      "type": "image/png",
+      "type": "image/svg+xml",
       "sizes": "512x512",
       "purpose": "any maskable"
     }


### PR DESCRIPTION
## Summary
- use correct content type for PWA icons

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing modules and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e67c73ff8832792e28507d0c2cf06