### PR TITLE
Add note folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Donoud is a straightforward to-do list and note-taking application built with Re
 - Color-code notes and edit them using a rich text editor.
 - Pin important notes so they stay at the top.
 - Sort notes by creation date or last update.
+- Organize notes into folders for easier filtering.
 
 ## Installation
 
@@ -37,6 +38,7 @@ To run the app locally, follow these steps:
 4. Use the input fields and buttons provided to make changes.
 5. Changes are automatically saved to local storage.
 6. Use the filtering options to efficiently organize and find tasks and notes.
+7. Create and manage note folders from the notes toolbar to keep related notes together.
 
 ## Contributing
 

--- a/src/Models/NoteFolder.ts
+++ b/src/Models/NoteFolder.ts
@@ -1,0 +1,5 @@
+export interface Folder {
+  id: string;
+  name: string;
+}
+

--- a/src/pages/notes/NoteEdit.tsx
+++ b/src/pages/notes/NoteEdit.tsx
@@ -25,7 +25,7 @@ import SelectNoteColor from "./editNoteToolbar/SelectNoteColor";
 const NoteEdit = () => {
   const navigate = useNavigate();
   const { noteId } = useParams();
-  const { getNoteById, updateNote } = useContext(NoteContext)!;
+  const { getNoteById, updateNote, folders } = useContext(NoteContext)!;
   let editedNote: Note | undefined;
   try {
     if (noteId) editedNote = getNoteById(noteId);
@@ -55,6 +55,24 @@ const NoteEdit = () => {
       >
         <div className=" container mt-4">
           <form onSubmit={handleSubmit}>
+            <div className="mb-2">
+              <select
+                className="form-select"
+                value={note?.folderId ?? ""}
+                onChange={(e) =>
+                  setNote((n) =>
+                    n ? { ...n, folderId: e.target.value || undefined } : n
+                  )
+                }
+              >
+                <option value="">No Folder</option>
+                {folders.map((f) => (
+                  <option key={f.id} value={f.id}>
+                    {f.name}
+                  </option>
+                ))}
+              </select>
+            </div>
             <div>
               <Paper elevation={4} sx={{ width: "auto", minHeight: "70vh" }}>
                 <MDXEditor

--- a/src/pages/notes/Notes.tsx
+++ b/src/pages/notes/Notes.tsx
@@ -32,11 +32,15 @@ const Notes = () => {
     deleteEmptyNotes,
     sortValue,
     orderReversed,
+    selectedFolder,
   } = useContext(NoteContext)!;
   const { filter } = useContext(FilterContext)!;
 
   const notes = allNotes
-    .filter((note) => note.text.includes(filter))
+    .filter((note) =>
+      note.text.includes(filter) &&
+      (selectedFolder ? note.folderId === selectedFolder : true)
+    )
     .sort((a, b) => {
       let difference = 0;
       if (sortValue === "Date created")

--- a/src/pages/notes/components/FolderMenu.tsx
+++ b/src/pages/notes/components/FolderMenu.tsx
@@ -1,0 +1,61 @@
+import { useContext } from "react";
+import NoteContext from "@/contexts/NoteContext";
+
+const FolderMenu = () => {
+  const {
+    folders,
+    selectedFolder,
+    setSelectedFolder,
+    createFolder,
+    renameFolder,
+    deleteFolder,
+  } = useContext(NoteContext)!;
+
+  const addFolder = () => {
+    const name = prompt("Folder name?");
+    if (name) createFolder(name);
+  };
+
+  const rename = () => {
+    const folder = folders.find((f) => f.id === selectedFolder);
+    const name = prompt("Rename folder", folder?.name);
+    if (name && selectedFolder) renameFolder(selectedFolder, name);
+  };
+
+  const remove = () => {
+    if (selectedFolder && confirm("Delete folder?")) deleteFolder(selectedFolder);
+  };
+
+  return (
+    <div className="d-flex align-items-center gap-1">
+      <select
+        className="form-select"
+        value={selectedFolder}
+        onChange={(e) => setSelectedFolder(e.target.value)}
+      >
+        <option value="">All Notes</option>
+        {folders.map((f) => (
+          <option key={f.id} value={f.id}>
+            {f.name}
+          </option>
+        ))}
+      </select>
+      <button className="btn btn-sm btn-secondary" onClick={addFolder}>
+        +
+      </button>
+      {selectedFolder && (
+        <>
+          <button className="btn btn-sm btn-secondary" onClick={rename}>
+            Rename
+          </button>
+          <button className="btn btn-sm btn-danger" onClick={remove}>
+            Delete
+          </button>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default FolderMenu;
+

--- a/src/pages/notes/components/SortBar.tsx
+++ b/src/pages/notes/components/SortBar.tsx
@@ -6,6 +6,7 @@ import Fade from "@mui/material/Fade";
 import { FaArrowDown } from "react-icons/fa6";
 import { EventHandler, MouseEventHandler, useContext, useState } from "react";
 import NoteContext from "../../../contexts/NoteContext";
+import FolderMenu from "./FolderMenu";
 
 function SortBar() {
   const {
@@ -27,7 +28,8 @@ function SortBar() {
 
   return (
     <Container>
-      <div className="d-flex flex-row-reverse">
+      <div className="d-flex justify-content-between">
+        <FolderMenu />
         <div>
           <button
             id="fade-button"


### PR DESCRIPTION
## Summary
- extend `Note` model and context for folders
- provide folder management and selection UI
- filter notes by folder
- allow changing a note's folder
- document folder usage

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: TypeScript errors about missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d41bc2c7083279155e105559c583e