### PR TITLE
Improve notes folder navigation and add menu

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -58,6 +58,47 @@ button .delete {
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
 }
 
+.note-folders {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.note-folders-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.note-folder-button {
+  border: 1px solid #3a3a3a;
+  background: #1f1f1f;
+  color: #f8f9fa;
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.9rem;
+  transition: all 0.2s ease;
+}
+
+.note-folder-button:hover {
+  border-color: #0d6efd;
+  color: #fff;
+}
+
+.note-folder-button.active {
+  background: #0d6efd;
+  border-color: #0d6efd;
+  color: #fff;
+}
+
+.note-folders-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .note {
   background-color: #272727;
   border-radius: 10px;

--- a/src/pages/notes/components/AddNoteFloatButton.tsx
+++ b/src/pages/notes/components/AddNoteFloatButton.tsx
@@ -1,31 +1,68 @@
-import { NoteAdd } from "@mui/icons-material";
-import { Fab } from "@mui/material";
-import { useContext } from "react";
+import { CreateNewFolder, NoteAdd } from "@mui/icons-material";
+import { Fab, Menu, MenuItem } from "@mui/material";
+import { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import NoteContext from "../../../contexts/NoteContext";
 
 export default function AddNoteFloatButton() {
   const navigate = useNavigate();
-  const { createNewNote } = useContext(NoteContext)!;
+  const { createNewNote, createFolder } = useContext(NoteContext)!;
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const open = Boolean(anchorEl);
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleAddNote = () => {
+    const newNoteId = createNewNote();
+    navigate(newNoteId);
+    handleClose();
+  };
+
+  const handleAddFolder = () => {
+    const name = prompt("Folder name?");
+    if (name) createFolder(name);
+    handleClose();
+  };
 
   return (
-    <Fab
-      color="primary"
-      style={{
-        margin: 0,
-        top: "auto",
-        right: 20,
-        bottom: 80,
-        left: "auto",
-        position: "fixed",
-      }}
-      aria-label="add"
-      onClick={() => {
-        const newNoteId = createNewNote();
-        navigate(newNoteId);
-      }}
-    >
-      <NoteAdd />
-    </Fab>
+    <>
+      <Fab
+        color="primary"
+        style={{
+          margin: 0,
+          top: "auto",
+          right: 20,
+          bottom: 80,
+          left: "auto",
+          position: "fixed",
+        }}
+        aria-label="add"
+        aria-controls={open ? "notes-add-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={(event) => setAnchorEl(event.currentTarget)}
+      >
+        <NoteAdd />
+      </Fab>
+      <Menu
+        id="notes-add-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: "top", horizontal: "left" }}
+        transformOrigin={{ vertical: "bottom", horizontal: "right" }}
+      >
+        <MenuItem onClick={handleAddNote}>
+          <NoteAdd className="me-2" />
+          Add note
+        </MenuItem>
+        <MenuItem onClick={handleAddFolder}>
+          <CreateNewFolder className="me-2" />
+          Add folder
+        </MenuItem>
+      </Menu>
+    </>
   );
 }

--- a/src/pages/notes/components/FolderMenu.tsx
+++ b/src/pages/notes/components/FolderMenu.tsx
@@ -1,4 +1,5 @@
 import { useContext } from "react";
+import { FaFolder } from "react-icons/fa";
 import NoteContext from "@/contexts/NoteContext";
 
 const FolderMenu = () => {
@@ -6,15 +7,9 @@ const FolderMenu = () => {
     folders,
     selectedFolder,
     setSelectedFolder,
-    createFolder,
     renameFolder,
     deleteFolder,
   } = useContext(NoteContext)!;
-
-  const addFolder = () => {
-    const name = prompt("Folder name?");
-    if (name) createFolder(name);
-  };
 
   const rename = () => {
     const folder = folders.find((f) => f.id === selectedFolder);
@@ -27,35 +22,47 @@ const FolderMenu = () => {
   };
 
   return (
-    <div className="d-flex align-items-center gap-1">
-      <select
-        className="form-select"
-        value={selectedFolder}
-        onChange={(e) => setSelectedFolder(e.target.value)}
-      >
-        <option value="">All Notes</option>
-        {folders.map((f) => (
-          <option key={f.id} value={f.id}>
-            {f.name}
-          </option>
+    <div className="note-folders">
+      <div className="note-folders-list">
+        <button
+          className={`note-folder-button${selectedFolder ? "" : " active"}`}
+          onClick={() => setSelectedFolder("")}
+          type="button"
+        >
+          All Notes
+        </button>
+        {folders.map((folder) => (
+          <button
+            key={folder.id}
+            className={`note-folder-button${selectedFolder === folder.id ? " active" : ""}`}
+            onClick={() => setSelectedFolder(folder.id)}
+            type="button"
+          >
+            <FaFolder className="me-2" />
+            {folder.name}
+          </button>
         ))}
-      </select>
-      <button className="btn btn-sm btn-secondary" onClick={addFolder}>
-        +
-      </button>
+      </div>
       {selectedFolder && (
-        <>
-          <button className="btn btn-sm btn-secondary" onClick={rename}>
+        <div className="note-folders-actions">
+          <button
+            className="btn btn-sm btn-outline-secondary"
+            onClick={rename}
+            type="button"
+          >
             Rename
           </button>
-          <button className="btn btn-sm btn-danger" onClick={remove}>
+          <button
+            className="btn btn-sm btn-outline-danger"
+            onClick={remove}
+            type="button"
+          >
             Delete
           </button>
-        </>
+        </div>
       )}
     </div>
   );
 };
 
 export default FolderMenu;
-

--- a/src/pages/notes/components/SortBar.tsx
+++ b/src/pages/notes/components/SortBar.tsx
@@ -28,7 +28,7 @@ function SortBar() {
 
   return (
     <Container>
-      <div className="d-flex justify-content-between">
+      <div className="d-flex flex-column flex-lg-row justify-content-between gap-3 align-items-lg-center">
         <FolderMenu />
         <div>
           <button


### PR DESCRIPTION
### Motivation
- The notes folder UI used a plain dropdown and a single-purpose add button, which made folder navigation and creation awkward to use.
- The goal is to provide clickable folder actions and let the add button offer both note and folder creation for a more intuitive UX.

### Description
- Replaced the `<select>` folder dropdown with clickable folder chips and an "All Notes" chip in `src/pages/notes/components/FolderMenu.tsx`, while preserving `renameFolder` and `deleteFolder` actions.
- Added styling for the new folder chips and actions in `src/index.css` (`.note-folders`, `.note-folders-list`, `.note-folder-button`, and `.note-folders-actions`).
- Updated the floating add button in `src/pages/notes/components/AddNoteFloatButton.tsx` to open a Material-UI `Menu` with two options that call `createNewNote` (navigates to the new note) and `createFolder` (prompts for a folder name).
- Adjusted the notes toolbar layout in `src/pages/notes/components/SortBar.tsx` to better align the folder chips with the sort controls.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready and serving on the expected port, indicating the app builds and serves successfully. (succeeded)
- Ran a Playwright script that navigated to `/notes` and captured a screenshot at `artifacts/notes-folders.png` to verify the updated UI rendering. (succeeded)
- No unit test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696de6e6301c8327919b53b5f02fb55e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Split action button now opens a menu with options to add notes or folders.
  * Redesigned folder management interface with button-based folder selection and visual icons.

* **UI Improvements**
  * Enhanced responsive layout for improved mobile viewing experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->